### PR TITLE
Reduce # of False Positives / Get-BadSuccessorOUPermissions.ps1

### DIFF
--- a/Get-BadSuccessorOUPermissions.ps1
+++ b/Get-BadSuccessorOUPermissions.ps1
@@ -72,6 +72,9 @@ function Get-BadSuccessorOUPermissions {
             if ($ace.AccessControlType -ne "Allow") {
                 continue
             }
+            if ($ace.PropagationFlags -eq "InheritOnly") { 
+                continue
+            }
             if ($ace.ActiveDirectoryRights -notmatch $relevantRights) {
                 continue
             }


### PR DESCRIPTION
Ignore **InheritOnly** ACEs because they are not relevant when the script iterates over all OUs anyway.

Additionally, without this fix, the script can produce False Positives because it does not consider the [InheritedObjectType](https://learn.microsoft.com/en-us/dotnet/api/system.security.accesscontrol.objectaccessrule.inheritedobjecttype?view=net-9.0) of the ACE which could have been set to scope the rule to specific object types only.